### PR TITLE
feat(middleware): Implement check role middelware

### DIFF
--- a/internal/middleware/check_role.go
+++ b/internal/middleware/check_role.go
@@ -1,15 +1,16 @@
 package middleware
 
 import (
-	"HireMeMaybe-backend/internal/util"
+	"HireMeMaybe-backend/internal/utilities"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
 
+// CheckRole will protect endpoint from user that is not a specific roles
 func CheckRole(role string) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		user := util.ExtractUser(ctx)
+		user := utilities.ExtractUser(ctx)
 
 		if user.Role != role {
 			ctx.AbortWithStatusJSON(http.StatusForbidden, gin.H{

--- a/internal/utilities/util.go
+++ b/internal/utilities/util.go
@@ -1,5 +1,5 @@
-// Package util contain utility code that use across the package
-package util
+// Package utilities contain utility code that use across the package
+package utilities
 
 import (
 	"HireMeMaybe-backend/internal/model"


### PR DESCRIPTION
## Description

-Implement role checking middleware

## Functional Acceptance Criteria (Not required for Documentation update)

**This middleware must be place after `requireAuth`**
API endpoint that have this middleware will limited access to authenticated user with specify role

Example: 

This endpoint: 
```
r.GET("/for-admin",middleware.requireAuth, middleware.checkRole(model.RoleAdmin), controller.adminHander)
```
Will return 200 if User are admin
Will return 401 if User not authenticated 
Will return 401 If User not admin

## Checklist
- [x] Linked issue
- [x] Linked GitHub Project item
- [] Tests added/updated
- [x] CI green (build, tests, SonarQube)
- [x] My code follows the Coding Guidelines.
